### PR TITLE
fix prefix mutation

### DIFF
--- a/error.go
+++ b/error.go
@@ -119,6 +119,10 @@ func Wrap(e interface{}, skip int) *Error {
 func WrapPrefix(e interface{}, prefix string, skip int) *Error {
 
 	err := Wrap(e, skip)
+	if err == e {
+		v := *err
+		err = &v
+	}
 
 	if err.prefix != "" {
 		err.prefix = fmt.Sprintf("%s: %s", prefix, err.prefix)

--- a/error_test.go
+++ b/error_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"runtime/debug"
 	"testing"
 )
@@ -144,7 +145,6 @@ func TestWrapPrefixError(t *testing.T) {
 		return WrapPrefix("hi", "prefix", 1)
 	}()
 
-	fmt.Println(e.Error())
 	if e.Error() != "prefix: hi" {
 		t.Errorf("Constructor with a string failed")
 	}
@@ -156,8 +156,8 @@ func TestWrapPrefixError(t *testing.T) {
 	prefixed := WrapPrefix(e, "prefix", 0)
 	original := e.(*Error)
 
-	if prefixed.Err != original.Err || &prefixed.stack != &original.stack || &prefixed.frames != &original.frames || prefixed.Error() != "prefix: prefix: hi" {
-		t.Errorf("Constructor with an Error failed")
+	if prefixed.Err != original.Err || !reflect.DeepEqual(prefixed.stack, original.stack) || !reflect.DeepEqual(prefixed.frames, original.frames) || prefixed.Error() != "prefix: prefix: hi" || !Is(prefixed, original) || !Is(original, prefixed) || prefixed.Unwrap().Error() != "hi" {
+		t.Errorf("Constructor with an Error failed: original=%s, prefixed=%s", original.Error(), prefixed.Error())
 	}
 
 	if WrapPrefix(nil, "prefix", 0).Error() != "prefix: <nil>" {


### PR DESCRIPTION
Problem: Calling `WrapPrefix` with a value that is already an `*error.Error` mutates the original error to add the prefix.

Fix: Copy the argument if it's already an `*error.Error`.